### PR TITLE
Comment skip, more error handling for parser.

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -261,6 +261,7 @@ class Parser:
             "EXTERN",
             "INLINE",
             "REGISTER",
+            "AUTO",
             "SIZEOF",
             "RESTRICT",
             "BOOLEAN",


### PR DESCRIPTION
Comments, multiline and singular are now skipped in the parse_external function. Error handling for expected identifiers have been added for parse_statement and parse_external. Finally, there is now error handling for deprecated keywords (commented out until they are fully deprecated/replaced).