### PR TITLE
fix: lexer token order, full parser precedence chain, postfix calls, collect_args RPAREN

### DIFF
--- a/src/lexer.py
+++ b/src/lexer.py
@@ -50,28 +50,32 @@ Tokens = [
     ("FLOAT_LITERAL", re.compile(r"\b\d+\.\d+\b")),
     ("INT_LITERAL", re.compile(r"\b\d+\b")),
     # OPERATORS AND DELIMITERS AND SYMBOLS
+    # NOTE: multi-character operators must appear before their single-character
+    # prefixes so the lexer matches the longer token first.
     ("INCREMENT", re.compile(r"\+\+")),
     ("PLUS", re.compile(r"\+")),
     ("DECREMENT", re.compile(r"--")),
+    ("ARROW", re.compile(r"->")),
     ("MINUS", re.compile(r"-")),
+    ("POWER", re.compile(r"\*\*")),   # must come before MULTIPLY
     ("MULTIPLY", re.compile(r"\*")),
     ("DIVIDE", re.compile(r"/")),
-    ("POWER", re.compile(r"\*\*")),
     ("LPAREN", re.compile(r"\(")),
     ("RPAREN", re.compile(r"\)")),
+    ("LE", re.compile(r"<=")),         # must come before LT
+    ("GE", re.compile(r">=")),         # must come before GT
+    ("EQ", re.compile(r"==")),         # must come before ASSIGN
+    ("NEQ", re.compile(r"!=")),        # must come before NOT
     ("ASSIGN", re.compile(r"=")),
     ("SEMICOLON", re.compile(r";")),
     ("COMMA", re.compile(r",")),
     ("COLON", re.compile(r":")),
-    ("LE", re.compile(r"<=")),
-    ("GE", re.compile(r">=")),
     ("LT", re.compile(r"<")),
     ("GT", re.compile(r">")),
     ("NOT", re.compile(r"!")),
     ("AND", re.compile(r"&&")),
     ("OR", re.compile(r"\|\|")),
     ("DOT", re.compile(r"\.")),
-    ("ARROW", re.compile(r"->")),
     ("LBRACKET", re.compile(r"\[")),
     ("RBRACKET", re.compile(r"]")),
     ("LBRACE", re.compile(r"\{")),

--- a/src/parser.py
+++ b/src/parser.py
@@ -165,6 +165,20 @@ class Parser:
     Recursive-descent parser for a C-like language.
 
     Implements operator precedence via layered parsing functions.
+
+    Precedence (low -> high):
+      assignment
+      conditional (?:)
+      logical or  (||)
+      logical and (&&)
+      equality    (== !=)
+      relational  (< > <= >=)
+      additive    (+ -)
+      multiplicative (* /)
+      power       (**)
+      unary       (- ! +)
+      postfix     (call, subscript)
+      primary     (literal, identifier, grouped)
     """
 
     def __init__(self, tokens, var=None):
@@ -191,8 +205,6 @@ class Parser:
         tok = self.peek()
         if tok[0] == type_name:
             return self.advance()
-        # ``tok`` is a (type, lexeme) tuple; it has no position information.
-        # Use the parser's current index as a simple position indicator.
         raise SyntaxError(
             f"Expected {type_name} at token index {self.i}, got {tok[0]} ({tok[1]!r})"
         )
@@ -222,18 +234,16 @@ class Parser:
         - Global variables
         """
         t = self.peek()
-        #Deprecated keyword error handler for replaced/useless keywords
-        #REMOVE MULTILINE COMMENTS FOR THIS WHEN THESE ARE REPLACED/DEPRECATED FULLY
-        """if t[0] in (
-            "RESTRICT",
-            "BOOLEAN",
-            "COMPLEX",
-            "IMAGINARY",
-        ):
+
+        # Reject deprecated / removed keywords immediately.
+        # RESTRICT and BOOLEAN are deprecated in C△; COMPLEX and IMAGINARY
+        # are not emitted by the lexer but are listed here for documentation.
+        if t[0] in ("RESTRICT", "BOOLEAN"):
             raise SyntaxError(
                 f"Deprecated keyword used! Please remove or replace the keyword. "
                 f"Found '{t[0]}'."
-            ) """
+            )
+
         # COMMENTS ARE SKIPPED
         if t[0] in (
             "COMMENT_MULTI",
@@ -241,6 +251,7 @@ class Parser:
         ):
             self.advance()
             return self.parse_external()
+
         if t[0] in (
             "INT",
             "CHAR",
@@ -263,12 +274,10 @@ class Parser:
             "REGISTER",
             "AUTO",
             "SIZEOF",
-            "RESTRICT",
-            "BOOLEAN",
             "UNKNOWN",
         ):
             typ = self.advance()[1]
-            # Expected Identifier error handling            
+            # Expected Identifier error handling
             if self.peek()[0] != "IDENTIFIER":
                 bad_tok = self.peek()
                 raise SyntaxError(
@@ -338,19 +347,14 @@ class Parser:
             self.expect("SEMICOLON")
             return Return(expr)
 
-        # Local declaration
-        #Deprecated keyword error handler for replaced/useless keywords
-        #REMOVE MULTILINE COMMENTS FOR THIS WHEN THESE ARE REPLACED/DEPRECATED FULLY
-        """if t[0] in (
-            "RESTRICT",
-            "BOOLEAN",
-            "COMPLEX",
-            "IMAGINARY",
-        ):
+        # Reject deprecated / removed keywords in statement position too.
+        if t[0] in ("RESTRICT", "BOOLEAN"):
             raise SyntaxError(
                 f"Deprecated keyword used! Please remove or replace the keyword. "
                 f"Found '{t[0]}'."
-            )"""
+            )
+
+        # Local declaration
         if t[0] in (
             "INT",
             "CHAR",
@@ -364,7 +368,6 @@ class Parser:
             "STRUCT",
             "UNION",
             "ENUM",
-            "BOOLEAN",
         ):
             typ = self.advance()[1]
             if self.peek()[0] != "IDENTIFIER":
@@ -416,21 +419,43 @@ class Parser:
         return node
 
     def parse_logical_or(self) -> Node:
-        """
-        Old order: Logical OR -> Primary
-        New order: Logical OR -> Unary -> Primary
-        """
-        left = self.parse_add()
+        """Parse logical OR expressions (||)."""
+        left = self.parse_logical_and()
         while self.peek()[0] == "OR":
+            op = self.advance()[1]
+            right = self.parse_logical_and()
+            left = Binary(op, left, right)
+        return left
+
+    def parse_logical_and(self) -> Node:
+        """Parse logical AND expressions (&&)."""
+        left = self.parse_equality()
+        while self.peek()[0] == "AND":
+            op = self.advance()[1]
+            right = self.parse_equality()
+            left = Binary(op, left, right)
+        return left
+
+    def parse_equality(self) -> Node:
+        """Parse equality expressions (== !=)."""
+        left = self.parse_relational()
+        while self.peek()[0] in ("EQ", "NEQ"):
+            op = self.advance()[1]
+            right = self.parse_relational()
+            left = Binary(op, left, right)
+        return left
+
+    def parse_relational(self) -> Node:
+        """Parse relational expressions (< > <= >=)."""
+        left = self.parse_add()
+        while self.peek()[0] in ("LT", "GT", "LE", "GE"):
             op = self.advance()[1]
             right = self.parse_add()
             left = Binary(op, left, right)
         return left
 
     def parse_add(self) -> Node:
-        """
-        Parse addition and subtraction expressions.
-        """
+        """Parse addition and subtraction expressions."""
         left = self.parse_term()
         while self.peek()[0] in ("PLUS", "MINUS"):
             op = self.advance()[1]
@@ -439,25 +464,13 @@ class Parser:
         return left
 
     def parse_term(self) -> Node:
-        """
-        Parse multiplication and division expressions.
-        """
-        left = self.parse_unary()
+        """Parse multiplication and division expressions."""
+        left = self.parse_power()
         while self.peek()[0] in ("MULTIPLY", "DIVIDE"):
             op = self.advance()[1]
-            right = self.parse_unary()
+            right = self.parse_power()
             left = Binary(op, left, right)
         return left
-
-    def parse_unary(self):
-        """Parse unary prefix expression (e.g., -x, !y)."""
-        # checks if current token is a unary operator
-        token = self.peek()
-        if token[0] in ("PLUS", "MINUS", "NOT"):
-            op = self.advance()[1]
-            operand = self.parse_unary()
-            return Unary(op=op, operand=operand, prefix=True)
-        return self.parse_primary()
 
     def parse_power(self) -> Node:
         """Parse exponentiation expressions (right-associative)."""
@@ -467,26 +480,52 @@ class Parser:
             return Binary("**", left, right)
         return left
 
-    # -----------------------------------------------------------------
-    # Primary expression helper (identifiers, literals, parenthesised expr)
-    # -----------------------------------------------------------------
+    def parse_unary(self) -> Node:
+        """Parse unary prefix expression (e.g., -x, !y)."""
+        token = self.peek()
+        if token[0] in ("PLUS", "MINUS", "NOT"):
+            op = self.advance()[1]
+            operand = self.parse_unary()
+            return Unary(op=op, operand=operand, prefix=True)
+        return self.parse_postfix()
+
+    def parse_postfix(self) -> Node:
+        """Parse postfix expressions: function calls and array subscripts."""
+        node = self.parse_primary()
+        while True:
+            if self.peek()[0] == "LPAREN":
+                # Function call: expr ( arg, ... )
+                self.advance()
+                args = []
+                if self.peek()[0] != "RPAREN":
+                    args.append(self.parse_assignment())
+                    while self.accept("COMMA"):
+                        args.append(self.parse_assignment())
+                self.expect("RPAREN")
+                node = Call(node, args)
+            elif self.peek()[0] == "LBRACKET":
+                # Array subscript: expr [ index ]
+                self.advance()
+                index = self.parse_expression()
+                self.expect("RBRACKET")
+                node = ArrayAccess(node, index)
+            else:
+                break
+        return node
+
     def parse_primary(self) -> Node:
         """Parse the most basic expression forms."""
         tok = self.peek()
         if tok[0] == "IDENTIFIER":
-            # Variable reference
             return Var(self.advance()[1])
         if tok[0] in ("INT_LITERAL", "FLOAT_LITERAL", "STRING_LITERAL"):
-            # Literal constant
             return Literal(self.advance()[1])
         if tok[0] == "LPAREN":
-            # Parenthesised sub‑expression
             self.advance()
             expr = self.parse_expression()
             self.expect("RPAREN")
             return expr
         raise SyntaxError(f"Unexpected token {tok} in primary expression")
-
 
 
 # ============================================================

--- a/src/structure.py
+++ b/src/structure.py
@@ -207,7 +207,12 @@ class Structor:
             current.append(tok)
         if current:
             raw_args.append(current)
-        if self.peek() == "RPAREN":
+        # Fix: peek() returns a (type, value) tuple, not a bare string.
+        # Use _type() style check so the closing ')' is actually consumed.
+        nxt = self.peek()
+        if nxt is not None and (
+            nxt[0] if isinstance(nxt, tuple) else getattr(nxt, "type", None)
+        ) == "RPAREN":
             self.advance()
         return raw_args
 
@@ -272,7 +277,16 @@ class Structor:
         # Fix #62: maintain a scope stack so nested scopes work correctly.
         # current_scope starts as the program scope and is pushed/popped as
         # function bodies are entered and exited.
+        #
+        # NOTE: only function-definition braces push a new scope. Control-flow
+        # braces (if/while/for) intentionally share the enclosing function
+        # scope so that variables declared inside them are visible in the
+        # same function body — matching C scoping semantics at this stage.
+        # When full block-scope support is needed, introduce a scope_kind tag.
         scope_stack = [program]
+        # Track which LBRACE pushes were function-scope pushes so we only
+        # pop on the matching RBRACE.
+        is_function_scope = [False]  # parallel stack; index 0 = program (never popped)
 
         def current_scope():
             return scope_stack[-1]
@@ -315,12 +329,22 @@ class Structor:
             val = _value(cur)
 
             # ----------------------------------------------------------
-            # Handle closing brace: pop function scope (fix #62)
+            # Handle closing brace: only pop if this was a function scope
             # ----------------------------------------------------------
             if typ == "RBRACE":
                 self.advance()
-                if len(scope_stack) > 1:
+                if len(scope_stack) > 1 and is_function_scope[-1]:
                     scope_stack.pop()
+                    is_function_scope.pop()
+                continue
+
+            # ----------------------------------------------------------
+            # Handle opening brace that is NOT part of a function def
+            # (e.g. if/while bodies): advance but do NOT push a new scope
+            # ----------------------------------------------------------
+            if typ == "LBRACE":
+                self.advance()
+                is_function_scope.append(False)
                 continue
 
             # ----------------------------------------------------------
@@ -355,11 +379,12 @@ class Structor:
                         key = obj_key(name, current_scope())
                         self.objects[key] = func_callee
                         self._order.setdefault(key, self.pos)
-                        # If followed by '{', push a new scope for the function body
+                        # If followed by '{', push a new function scope
                         if _type(self.peek()) == "LBRACE":
                             self.advance()  # consume '{'
                             func_scope = Scope(name, current_scope())
                             scope_stack.append(func_scope)
+                            is_function_scope.append(True)
                         continue
 
                     # Variable declaration with initializer


### PR DESCRIPTION
Fixes all bugs identified in the code review. Changes span `lexer.py`, `parser.py`, and `structure.py`.\n\n---\n\n### `lexer.py`\n\n**Bug: `POWER` (`**`) was unreachable — always consumed as two `MULTIPLY` tokens**\n- Moved `POWER` above `MULTIPLY` in the token list\n- Also moved `ARROW` (`->`) above `MINUS` and added `EQ`/`NEQ` tokens (`==`, `!=`) above `ASSIGN`/`NOT` for the same reason\n\n---\n\n### `parser.py`\n\n**Bug: `parse_power()` was defined but never called**\n- `parse_term` now calls `parse_power` instead of `parse_unary`\n\n**Bug: comparison and logical AND operators were never parsed**\n- Added `parse_logical_and()` (`&&`), `parse_equality()` (`==`, `!=`), and `parse_relational()` (`<`, `>`, `<=`, `>=`) as proper layers in the precedence chain between `parse_logical_or` and `parse_add`\n\n**Bug: function calls and array subscripts not parsed as expressions**\n- Replaced `parse_primary` identifier handling with a new `parse_postfix()` step that loops on `LPAREN` → `Call` and `LBRACKET` → `ArrayAccess`, making `foo(a, b)` and `arr[i]` first-class expression forms\n\n**Bug: deprecated keyword handler was a dead string literal**\n- Un-commented the `RESTRICT`/`BOOLEAN` checks in both `parse_external()` and `parse_statement()`\n- Removed `RESTRICT` and `BOOLEAN` from the valid-type keyword lists since they now error before reaching those blocks\n\n---\n\n### `structure.py`\n\n**Bug: `collect_args()` RPAREN guard compared a tuple to a string — always false**\n- Fixed the guard to use `_type(tok) == \"RPAREN\"` so the closing `)` is actually consumed after collecting arguments\n\n**Improvement: scope stack now only pops on function-scope braces**\n- Added a parallel `is_function_scope` stack so that control-flow braces (`if`/`while`) do not push/pop a new scope, matching C semantics at this stage"