### PR TITLE
Removed macOS references in documentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ The C△ compiler and standard library support multiple architectures:
 
 ## Install Guide
 
-1. Make sure you have **Linux or MacOS** and **Python 3.14+**
+1. Make sure you have **Linux** and **Python 3.14+**
 2. Clone the repo and `cd` into it
 3. Run `make full-install`
 

--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,7 @@ The C△ compiler and standard library support multiple architectures:
 
 ### Standard Library (plstd) Architecture Support
 
-- **printd.plib** — Type-aware printing with conditional compilation for both x86_64 Linux and ARM64 macOS
+- **printd.plib** — Type-aware printing with conditional compilation for both x86_64 Linux
 - **string.plib** — String operations (strcmp, strcpy, strcat, etc.) optimized for each architecture
 - **streamer.plib** — File I/O and syscall wrappers supporting both architectures
 - **Syscalls** — All syscalls use platform-specific conventions:

--- a/docs/assembly.md
+++ b/docs/assembly.md
@@ -22,7 +22,7 @@ asm functionName(params) {
 - **Parameters** use native C△ type declarations instead of assembler directives.
 - syntax describes what syntax is being used
 - Every `asm` block must explicitly declare its text section for the selected syntax.
-  Use `section .text` for x86_64 NASM targets and `.section __TEXT,__text` for `arm64_macho`.
+  Use `section .text` for x86_64 NASM targets
 - `return;` emits `ret`; `return expr;` moves the expression result to `rax` on x86_64 or `x0` on ARM64 before returning.
 - Variable declarations inside `asm` blocks may omit semicolons; newlines terminate ASM declarations and instructions.
 - Each `asm` block becomes its **own `.asm` file**.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -37,6 +37,18 @@ The Hypotenuse Compiler transforms C△ source files into native Linux ELF x86_6
 
 ---
 
+## Target
+
+| Details           | Linux      |
+| ----------------- | ---------- |
+| Architecture      | x86_64     |
+| Platform          | Linux      |
+| Output format     | ELF        |
+| Backend           | GCC + NASM |
+| Compiler language | Python 3   |
+
+---
+
 ## Stage Details
 
 ### 1. Lexer (`lexer.py`)

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -117,12 +117,3 @@ python3 src/main.py -i mylib.plib
 
 ---
 
-## Target
-
-| Details           | Linux      | MacOS      |
-| ----------------- | ---------- | ---------- |
-| Architecture      | x86_64     | arm64      |
-| Platform          | Linux      | MacOS      |
-| Output format     | ELF        | machO      |
-| Backend           | GCC + NASM | GCC + NASM |
-| Compiler language | Python 3   | Python 3   |

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -35,20 +35,6 @@ The Hypotenuse Compiler transforms C△ source files into native Linux ELF x86_6
   7 Linker                          ──▶  native ELF binary
 ```
 
----
-
-## Target
-
-| Details           | Linux      |
-| ----------------- | ---------- |
-| Architecture      | x86_64     |
-| Platform          | Linux      |
-| Output format     | ELF        |
-| Backend           | GCC + NASM |
-| Compiler language | Python 3   |
-
----
-
 ## Stage Details
 
 ### 1. Lexer (`lexer.py`)
@@ -129,3 +115,12 @@ python3 src/main.py -i mylib.plib
 
 ---
 
+## Target
+
+| Details           | Linux      |
+| ----------------- | ---------- |
+| Architecture      | x86_64     |
+| Platform          | Linux      |
+| Output format     | ELF        |
+| Backend           | GCC + NASM |
+| Compiler language | Python 3   |


### PR DESCRIPTION
#129
Changes made in:
- README.MD 
- docs/assembly.md
- docs/compiler.md